### PR TITLE
Show full images in highlights grid

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -78,6 +78,14 @@ main{flex:1 0 auto;}
   height:300px;
   width:100%;
 }
+
+/* ------------ Homepage Flipper-Highlights ----------------------- */
+#homeFlipperGrid .card-img-top{
+  object-fit:contain;    /* komplette Bilder anzeigen */
+  height:200px;         /* einheitliche Höhe */
+  padding:.5rem;        /* etwas Abstand zum Kartenrand */
+  background:#fff;      /* neutraler Hintergrund */
+}
 .card-body p:last-child{margin-bottom:0;}
 
 /* --------------------------------------------------


### PR DESCRIPTION
## Summary
- add a more specific rule to show the full pinball image on the home page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6878ae644d98833189a44452f812bc22