### PR TITLE
Add dark mode styling with alternate logos

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -13,6 +13,10 @@
   --bs-link-hover-color:#A52317;
 }
 
+/* Logo default visibility */
+.logo-dark { display:none; }
+.logo-light { display:inline-block; }
+
 /* --------------------------------------------------
    Basis‑Layout
 -------------------------------------------------- */
@@ -478,3 +482,29 @@ footer a:hover{color:var(--bs-primary);text-decoration:underline;}
   .navbar-toggler:focus{
     box-shadow:none;
   }
+
+/* --------------------------------------------------
+   Dark Mode Overrides
+-------------------------------------------------- */
+@media (prefers-color-scheme: dark) {
+  body {
+    background:#121212;
+    color:#f8f9fa;
+  }
+  .navbar,
+  .navbar.navbar-light,
+  .glassnav {
+    background:#121212!important;
+  }
+  .navbar .nav-link,
+  .navbar-brand {
+    color:#f8f9fa!important;
+  }
+  .bg-light,
+  footer.bg-light {
+    background:#1e1e1e!important;
+    border-color:#333!important;
+  }
+  .logo-light { display:none; }
+  .logo-dark { display:inline-block; }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,7 +48,11 @@
     <div class="container-fluid">
       <a class="navbar-brand" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='images/logo.png') }}"
-             alt="Logo" height="32" class="d-inline-block align-text-top">
+             alt="Logo" height="32"
+             class="d-inline-block align-text-top logo-light">
+        <img src="{{ url_for('static', filename='images/logo_dark.png') }}"
+             alt="Logo" height="32"
+             class="d-inline-block align-text-top logo-dark">
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
         <span class="navbar-toggler-icon"></span>
@@ -77,7 +81,10 @@
         <div class="col-md-6">
           <img src="{{ url_for('static', filename='images/Logo.png') }}"
                alt="Aixtraball Logo"
-               class="footer-logo mb-2">
+               class="footer-logo mb-2 logo-light">
+          <img src="{{ url_for('static', filename='images/Logo_dark.png') }}"
+               alt="Aixtraball Logo"
+               class="footer-logo mb-2 logo-dark">
           <p class="mb-1">Merzbrück 210<br>52146 Würselen</p>
           <p class="mb-0">
             E-Mail: <a href="mailto:info@aixtraball.de">info@aixtraball.de</a>


### PR DESCRIPTION
## Summary
- support dark mode CSS
- swap to alternate logos when in dark mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6878ca33cbf48331bdf28bd7c8ada4e2