### PR TITLE
Fix dark mode burger icon visibility

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -544,6 +544,10 @@ footer a:hover{color:var(--bs-primary);text-decoration:underline;}
     color:#222;
     border-color:#f8f9fa;
   }
+  /* Ensure the burger menu icon remains visible */
+  .navbar-toggler-icon {
+    filter: invert(1);
+  }
   .logo-light { display:none !important; }
   .logo-dark { display:inline-block !important; }
 }


### PR DESCRIPTION
## Summary
- ensure navbar burger icon is visible in dark mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68889ac795e483318ca9a0f490fcfead