### PR TITLE
Fix dark text on flipper and team pages

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -487,58 +487,58 @@ footer a:hover{color:var(--bs-primary);text-decoration:underline;}
    Dark Mode Overrides
 -------------------------------------------------- */
 @media (prefers-color-scheme: dark) {
-  body {
+  body:not(.light-mode) {
     background:#121212;
     color:#f8f9fa;
   }
-  .navbar,
-  .navbar.navbar-light,
-  .glassnav {
+  body:not(.light-mode) .navbar,
+  body:not(.light-mode) .navbar.navbar-light,
+  body:not(.light-mode) .glassnav {
     background:#121212!important;
   }
-  .navbar .nav-link,
-  .navbar-brand {
+  body:not(.light-mode) .navbar .nav-link,
+  body:not(.light-mode) .navbar-brand {
     color:#f8f9fa!important;
   }
-  .bg-light,
-  footer.bg-light {
+  body:not(.light-mode) .bg-light,
+  body:not(.light-mode) footer.bg-light {
     background:#1e1e1e!important;
     border-color:#333!important;
   }
-  .card,
-  .accordion-item {
+  body:not(.light-mode) .card,
+  body:not(.light-mode) .accordion-item {
     background:#1e1e1e;
     color:#f8f9fa;
     border-color:#333;
   }
-  .accordion-button {
+  body:not(.light-mode) .accordion-button {
     background:#1e1e1e;
     color:#f8f9fa;
   }
-  .accordion-button:not(.collapsed) {
+  body:not(.light-mode) .accordion-button:not(.collapsed) {
     background:rgba(var(--bs-primary-rgb),.25);
     color:#f8f9fa;
   }
-  .member-info {
+  body:not(.light-mode) .member-info {
     background:#1e1e1e;
     color:#f8f9fa;
     border-color:#444;
   }
-  .form-control {
+  body:not(.light-mode) .form-control {
     background:#1e1e1e;
     color:#f8f9fa;
     border-color:#333;
   }
-  .btn-outline-danger {
+  body:not(.light-mode) .btn-outline-danger {
     color:#f8f9fa;
     border-color:#f8f9fa;
   }
-  .btn-outline-danger:hover,
-  .btn-outline-danger:focus {
+  body:not(.light-mode) .btn-outline-danger:hover,
+  body:not(.light-mode) .btn-outline-danger:focus {
     background:#f8f9fa;
     color:#121212;
     border-color:#f8f9fa;
   }
-  .logo-light { display:none !important; }
-  .logo-dark { display:inline-block !important; }
+  body:not(.light-mode) .logo-light { display:none !important; }
+  body:not(.light-mode) .logo-dark { display:inline-block !important; }
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -43,7 +43,7 @@
   {% block head_extra %}{% endblock %}
 </head>
 
-<body>
+<body{% if body_class %} class="{{ body_class }}"{% endif %}>
   <nav class="navbar navbar-expand-lg navbar-light fixed-top">
     <div class="container-fluid">
       <a class="navbar-brand" href="{{ url_for('index') }}">

--- a/app/templates/flipper_all.html
+++ b/app/templates/flipper_all.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set body_class = 'light-mode' %}
 {# app/templates/flipper_all.html #}
 
 {% block head_extra %}

--- a/app/templates/team.html
+++ b/app/templates/team.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set body_class = 'light-mode' %}
 
 {% block head_extra %}
   <link rel="stylesheet"


### PR DESCRIPTION
## Summary
- add optional `body_class` handling in `base.html`
- exclude pages from dark mode via `light-mode` body class
- mark flipper and team pages to stay in light mode

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6888a0960a8883319f9614c7b7177458