### PR TITLE
Remove dark mode styling

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -13,10 +13,6 @@
   --bs-link-hover-color:#A52317;
 }
 
-/* Logo default visibility */
-.logo-dark { display:none !important; }
-.logo-light { display:inline-block !important; }
-
 /* --------------------------------------------------
    Basis‑Layout
 -------------------------------------------------- */
@@ -482,63 +478,3 @@ footer a:hover{color:var(--bs-primary);text-decoration:underline;}
   .navbar-toggler:focus{
     box-shadow:none;
   }
-
-/* --------------------------------------------------
-   Dark Mode Overrides
--------------------------------------------------- */
-@media (prefers-color-scheme: dark) {
-  body:not(.light-mode) {
-    background:#121212;
-    color:#f8f9fa;
-  }
-  body:not(.light-mode) .navbar,
-  body:not(.light-mode) .navbar.navbar-light,
-  body:not(.light-mode) .glassnav {
-    background:#121212!important;
-  }
-  body:not(.light-mode) .navbar .nav-link,
-  body:not(.light-mode) .navbar-brand {
-    color:#f8f9fa!important;
-  }
-  body:not(.light-mode) .bg-light,
-  body:not(.light-mode) footer.bg-light {
-    background:#1e1e1e!important;
-    border-color:#333!important;
-  }
-  body:not(.light-mode) .card,
-  body:not(.light-mode) .accordion-item {
-    background:#1e1e1e;
-    color:#f8f9fa;
-    border-color:#333;
-  }
-  body:not(.light-mode) .accordion-button {
-    background:#1e1e1e;
-    color:#f8f9fa;
-  }
-  body:not(.light-mode) .accordion-button:not(.collapsed) {
-    background:rgba(var(--bs-primary-rgb),.25);
-    color:#f8f9fa;
-  }
-  body:not(.light-mode) .member-info {
-    background:#1e1e1e;
-    color:#f8f9fa;
-    border-color:#444;
-  }
-  body:not(.light-mode) .form-control {
-    background:#1e1e1e;
-    color:#f8f9fa;
-    border-color:#333;
-  }
-  body:not(.light-mode) .btn-outline-danger {
-    color:#f8f9fa;
-    border-color:#f8f9fa;
-  }
-  body:not(.light-mode) .btn-outline-danger:hover,
-  body:not(.light-mode) .btn-outline-danger:focus {
-    background:#f8f9fa;
-    color:#121212;
-    border-color:#f8f9fa;
-  }
-  body:not(.light-mode) .logo-light { display:none !important; }
-  body:not(.light-mode) .logo-dark { display:inline-block !important; }
-}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -49,10 +49,7 @@
       <a class="navbar-brand" href="{{ url_for('index') }}">
         <img src="{{ url_for('static', filename='images/logo.png') }}"
              alt="Logo" height="32"
-             class="d-inline-block align-text-top logo-light">
-        <img src="{{ url_for('static', filename='images/logo_dark.png') }}"
-             alt="Logo" height="32"
-             class="d-inline-block align-text-top logo-dark">
+             class="d-inline-block align-text-top">
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
         <span class="navbar-toggler-icon"></span>
@@ -81,10 +78,7 @@
         <div class="col-md-6">
           <img src="{{ url_for('static', filename='images/Logo.png') }}"
                alt="Aixtraball Logo"
-               class="footer-logo mb-2 logo-light">
-          <img src="{{ url_for('static', filename='images/Logo_dark.png') }}"
-               alt="Aixtraball Logo"
-               class="footer-logo mb-2 logo-dark">
+               class="footer-logo mb-2">
           <p class="mb-1">Merzbrück 210<br>52146 Würselen</p>
           <p class="mb-0">
             E-Mail: <a href="mailto:info@aixtraball.de">info@aixtraball.de</a>

--- a/app/templates/flipper_all.html
+++ b/app/templates/flipper_all.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% set body_class = 'light-mode' %}
 {# app/templates/flipper_all.html #}
 
 {% block head_extra %}

--- a/app/templates/team.html
+++ b/app/templates/team.html
@@ -1,6 +1,4 @@
 {% extends "base.html" %}
-{% set body_class = 'light-mode' %}
-
 {% block head_extra %}
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css" />


### PR DESCRIPTION
## Summary
- remove dark mode overrides and related logo toggling
- drop page-specific light-mode flags

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fbd5aa62c833193b6fbbf46e584b4