### PR TITLE
Fix animation direction for next opening section

### DIFF
--- a/app/static/css/custom.css
+++ b/app/static/css/custom.css
@@ -179,7 +179,8 @@ a,
 }
 
 /* -------- Section reveal animation --------------- */
-.reveal{opacity:0;transform:translateY(40px);transition:opacity .6s ease,transform .6s ease;}
+.reveal{opacity:0;transform:translateY(-40px);transition:opacity .6s ease,transform .6s ease;}
+.reveal.reveal-bottom{transform:translateY(40px);}
 .reveal-visible{opacity:1;transform:none;}
 
 /* ==============================================================

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,12 +22,11 @@
   <div class="hero-overlay d-flex flex-column justify-content-center align-items-center text-center">
     <h1 class="display-4 fw-bold mb-3">Dein Flipperverein in der Städteregion Aachen</h1>
     <p class="lead mb-4">Retro-Gaming trifft Community – jeden letzten Sonntag für dich geöffnet!</p>
-    <a href="{{ url_for('flipper_all') }}" class="btn btn-primary btn-lg">Jetzt entdecken</a>
   </div>
 </section>
 
 {# ID hinzugefügt, bg-light entfernt, Padding leicht reduziert (py-4 statt py-5) #}
-<section id="next-opening-section" class="py-4 reveal">
+<section id="next-opening-section" class="py-4 reveal reveal-bottom">
   <div class="container text-center">
     {% if opening %}
       {# Optional: Icon hinzugefügt (benötigt Bootstrap Icons o.ä.) #}


### PR DESCRIPTION
## Summary
- Animate "Nächster Öffnungstag" section from bottom to top to avoid image edge artifacts
- Remove "Jetzt entdecken" button from homepage hero

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896588b8c808331902a51054b8ff882