### PR TITLE
Fix hidden next opening day text

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -27,7 +27,7 @@
 
 {# ID hinzugefügt, bg-light entfernt, Padding auf Container verschoben (py-4) #}
 <section id="next-opening-section">
-  <div class="container text-center py-4 reveal reveal-bottom">
+  <div class="container text-center py-4">
     {% if opening %}
       {# Optional: Icon hinzugefügt (benötigt Bootstrap Icons o.ä.) #}
       <h2 class="fw-bold mb-3"><i class="bi bi-calendar-event me-2"></i>Nächster Öffnungstag</h2>
@@ -112,13 +112,8 @@
       });
     }, { threshold: 0.1 });
 
-    const nextOpening = document.querySelector('#next-opening-section .reveal');
-    if (nextOpening) {
-      requestAnimationFrame(() => nextOpening.classList.add('reveal-visible'));
-    }
-
     document.querySelectorAll('.reveal').forEach(el => {
-      if (el !== nextOpening) observer.observe(el);
+      observer.observe(el);
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- Ensure the 'Nächster Öffnungstag' section displays its text by default
- Simplify reveal script to observe only scroll-revealed sections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896627588b883319953a9e9ccca3bff