### PR TITLE
Security hardening: CSRF, security headers, XSS sanitization, path traversal fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 TZ=Europe/Berlin
 
+# Pflichtfeld: starkes zufälliges Secret für Sessions
+# Generieren mit: python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=change-me-generate-a-real-secret
+
 # Zugangsdaten für den Admin-Bereich
 ADMIN_USER=cremer
 ADMIN_PASSWORD=changeme
@@ -16,3 +20,7 @@ SMTP_PASSWORD=change-me
 SMTP_SENDER=kontakt@example.com
 SMTP_RECIPIENTS=vorstand@example.com,support@example.com
 SMTP_USE_TLS=true
+
+# Optional: Rate-Limiting Kontaktformular (Standardwerte)
+# CONTACT_MAX_ATTEMPTS=5
+# CONTACT_WINDOW_SECONDS=600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Run unit tests
         run: pytest
+        env:
+          SECRET_KEY: "ci-testing-only-not-a-real-secret"
 
   docker:
     needs: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   Stage 1 – Builder
 #   Builds ALL wheels incl. dependencies
 # ============================================
-FROM python:3.14-slim-bookworm AS builder
+FROM python:3.13-slim-bookworm AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -28,7 +28,7 @@ RUN python -m pip install --upgrade pip wheel \
 #   Stage 2 – Runtime
 #   Minimal image, offline install from wheels
 # ============================================
-FROM python:3.14-slim-bookworm AS runtime
+FROM python:3.13-slim-bookworm AS runtime
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates \
@@ -75,5 +75,5 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
 
 USER ${APP_UID}:${APP_UID}
 
-ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:5000 --workers=2 --threads=2 --worker-tmp-dir=/tmp/app --access-logfile=- --error-logfile=- --graceful-timeout=30 --timeout=30"
+ENV GUNICORN_CMD_ARGS="--bind=0.0.0.0:5000 --workers=2 --threads=2 --worker-tmp-dir=/tmp/app --access-logfile=- --error-logfile=- --graceful-timeout=30 --timeout=30 --max-requests=1000 --max-requests-jitter=100"
 CMD ["gunicorn", "-c", "/app/gunicorn.conf.py", "app:app"]

--- a/app/app.py
+++ b/app/app.py
@@ -305,7 +305,7 @@ def send_contact_email(payload: dict):
 
 def save_news_settings(new_settings: dict):
     """Persist news settings and invalidate cache."""
-    filepath = CONFIG_DIR / NEWS_SETTINGS_FILE
+    filepath = _config_dir() / NEWS_SETTINGS_FILE
     yaml_content = yaml.safe_dump(new_settings, allow_unicode=True, sort_keys=False)
     filepath.write_text(yaml_content, encoding="utf-8")
     try:
@@ -318,11 +318,17 @@ def save_news_settings(new_settings: dict):
 # --------------------------------------------------
 YAML_CACHE = {}
 
+
+def _config_dir() -> Path:
+    """Return the active config directory (overridable via app.config for tests)."""
+    return Path(app.config.get("CONFIG_DIR", CONFIG_DIR))
+
 def load_yaml(filename: str):
     """Beliebige YAML‑Datei aus dem config‑Ordner laden (mtime‑Cache).
     Returns a deep copy to prevent accidental mutation of cached data.
+    CONFIG_DIR can be overridden via app.config["CONFIG_DIR"] (used in tests).
     """
-    path = CONFIG_DIR / filename
+    path = _config_dir() / filename
     try:
         mtime = path.stat().st_mtime
     except FileNotFoundError:
@@ -829,7 +835,7 @@ def admin():
 def admin_edit(filename):
     if filename not in ADMIN_SECTIONS:
         abort(404)
-    filepath = CONFIG_DIR / filename
+    filepath = _config_dir() / filename
     if request.method == "POST":
         json_data = request.form.get("content", "")
         try:
@@ -893,7 +899,7 @@ def admin_item(filename, index=None):
     if section.get("read_only"):
         abort(403)
     schema = section.get("schema")
-    filepath = CONFIG_DIR / filename
+    filepath = _config_dir() / filename
     data = load_yaml(filename)
     base_item = {}
     if index is not None and index < len(data):
@@ -1024,7 +1030,7 @@ def admin_delete(filename, index):
     removed = data.pop(index)
     schema = section.get("schema")
     cleanup_entry_media(removed, schema)
-    filepath = CONFIG_DIR / filename
+    filepath = _config_dir() / filename
     yaml_content = yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
     filepath.write_text(yaml_content, encoding="utf-8")
     try:
@@ -1224,7 +1230,7 @@ def kontakt():
     ip = request.remote_addr or "?"
 
     def _save_submission(payload: dict):
-        path = CONFIG_DIR / "contact_submissions.yaml"
+        path = _config_dir() / "contact_submissions.yaml"
         try:
             existing = []
             if path.exists():
@@ -1331,7 +1337,8 @@ def impressum():
 
 @app.route("/robots.txt")
 def robots():
-    txt = "User-agent: *\nAllow: /\nSitemap: https://aixtraball.de/sitemap.xml"
+    sitemap_url = url_for('sitemap', _external=True)
+    txt = f"User-agent: *\nAllow: /\nSitemap: {sitemap_url}"
     return Response(txt, mimetype="text/plain")
 
 @app.route("/sitemap.xml")
@@ -1341,7 +1348,10 @@ def sitemap():
         {"loc": url_for('flipper_all',_external=True)},
         {"loc": url_for('verein',     _external=True)},
         {"loc": url_for('team',       _external=True)},
-        {"loc": url_for('news_list',  _external=True)}
+        {"loc": url_for('news_list',  _external=True)},
+        {"loc": url_for('preise',     _external=True)},
+        {"loc": url_for('kontakt',    _external=True)},
+        {"loc": url_for('impressum',  _external=True)},
     ]
     # alle News‑Artikel
     for n in load_news_items():

--- a/app/app.py
+++ b/app/app.py
@@ -31,18 +31,8 @@ try:
     from flask_compress import Compress
 except Exception:
     Compress = None
-try:
-    from flask_wtf.csrf import CSRFProtect
-    _csrf_available = True
-except Exception:
-    CSRFProtect = None
-    _csrf_available = False
-try:
-    import bleach as _bleach
-    _bleach_available = True
-except Exception:
-    _bleach = None
-    _bleach_available = False
+from flask_wtf.csrf import CSRFProtect
+import bleach
 import hmac
 import re
 import pyotp
@@ -55,12 +45,10 @@ from werkzeug.utils import secure_filename
 app = Flask(__name__)
 _secret_key = os.environ.get("SECRET_KEY")
 if not _secret_key and not app.config.get("TESTING"):
-    import sys
-    if not any(arg in sys.argv[0] for arg in ("pytest", "test")):
-        raise RuntimeError(
-            "SECRET_KEY environment variable must be set. "
-            "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
-        )
+    raise RuntimeError(
+        "SECRET_KEY environment variable must be set. "
+        "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+    )
 app.secret_key = _secret_key or "testing-only-insecure-key"
 
 # Performance: cache static files long and enable simple cache-busting
@@ -78,9 +66,7 @@ except Exception:
 if Compress is not None:
     Compress(app)
 
-# CSRF protection
-if _csrf_available:
-    csrf = CSRFProtect(app)
+csrf = CSRFProtect(app)
 
 # HTML sanitisation allowlist (for admin-editable rich-text fields)
 _ALLOWED_TAGS = [
@@ -100,9 +86,7 @@ def sanitize_html(value):
     """Sanitize HTML from admin rich-text fields using a tag/attr allowlist."""
     if not isinstance(value, str):
         return value
-    if _bleach_available:
-        return _bleach.clean(value, tags=_ALLOWED_TAGS, attributes=_ALLOWED_ATTRS)
-    return value
+    return bleach.clean(value, tags=_ALLOWED_TAGS, attributes=_ALLOWED_ATTRS)
 
 
 # YouTube URL validation – only allow known YouTube domains
@@ -112,11 +96,8 @@ _YOUTUBE_RE = re.compile(
 
 
 def _safe_youtube_embed(url):
-    """Convert a YouTube watch URL to a privacy-enhanced embed URL, or return ''."""
     m = _YOUTUBE_RE.match(url or "")
-    if not m:
-        return ""
-    return f"https://www.youtube-nocookie.com/embed/{m.group(1)}"
+    return f"https://www.youtube-nocookie.com/embed/{m.group(1)}" if m else ""
 
 
 ADMIN_USER = os.environ.get("ADMIN_USER", "admin")
@@ -321,7 +302,7 @@ YAML_CACHE = {}
 
 def _config_dir() -> Path:
     """Return the active config directory (overridable via app.config for tests)."""
-    return Path(app.config.get("CONFIG_DIR", CONFIG_DIR))
+    return app.config.get("CONFIG_DIR", CONFIG_DIR)
 
 def load_yaml(filename: str):
     """Beliebige YAML‑Datei aus dem config‑Ordner laden (mtime‑Cache).
@@ -619,35 +600,36 @@ def asset(path: str):
         return path
     return url_for("static", filename=path)
 
-@app.template_filter("safe_youtube_embed")
-def safe_youtube_embed_filter(url):
-    """Convert YouTube watch URL to privacy-enhanced embed URL."""
-    return _safe_youtube_embed(url)
+app.jinja_env.filters["safe_youtube_embed"] = _safe_youtube_embed
 
 # --------------------------------------------------
 # Security Headers
 # --------------------------------------------------
+_CSP_HEADER = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com "
+    "https://unpkg.com https://analytics.aixtraball.de; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com "
+    "https://fonts.googleapis.com https://unpkg.com; "
+    "font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; "
+    "img-src 'self' data: https:; "
+    "frame-src https://www.youtube-nocookie.com https://www.youtube.com; "
+    "connect-src 'self' https://analytics.aixtraball.de; "
+    "base-uri 'self'; "
+    "form-action 'self';"
+)
+_SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+    "Content-Security-Policy": _CSP_HEADER,
+}
+
 @app.after_request
 def set_security_headers(response):
-    response.headers.setdefault("X-Content-Type-Options", "nosniff")
-    response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
-    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
-    response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
-    # CSP: inline scripts/styles kept for Bootstrap + custom JS; frame-src for YouTube
-    csp = (
-        "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com "
-        "https://unpkg.com https://analytics.aixtraball.de; "
-        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com "
-        "https://fonts.googleapis.com https://unpkg.com; "
-        "font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; "
-        "img-src 'self' data: https:; "
-        "frame-src https://www.youtube-nocookie.com https://www.youtube.com; "
-        "connect-src 'self' https://analytics.aixtraball.de; "
-        "base-uri 'self'; "
-        "form-action 'self';"
-    )
-    response.headers.setdefault("Content-Security-Policy", csp)
+    for header, value in _SECURITY_HEADERS.items():
+        response.headers.setdefault(header, value)
     return response
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -31,7 +31,20 @@ try:
     from flask_compress import Compress
 except Exception:
     Compress = None
+try:
+    from flask_wtf.csrf import CSRFProtect
+    _csrf_available = True
+except Exception:
+    CSRFProtect = None
+    _csrf_available = False
+try:
+    import bleach as _bleach
+    _bleach_available = True
+except Exception:
+    _bleach = None
+    _bleach_available = False
 import hmac
+import re
 import pyotp
 from werkzeug.security import check_password_hash, generate_password_hash
 from werkzeug.utils import secure_filename
@@ -40,10 +53,20 @@ from werkzeug.utils import secure_filename
 # Grundkonfiguration
 # --------------------------------------------------
 app = Flask(__name__)
-app.secret_key = os.environ.get("SECRET_KEY", "change-me")
+_secret_key = os.environ.get("SECRET_KEY")
+if not _secret_key and not app.config.get("TESTING"):
+    import sys
+    if not any(arg in sys.argv[0] for arg in ("pytest", "test")):
+        raise RuntimeError(
+            "SECRET_KEY environment variable must be set. "
+            "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+        )
+app.secret_key = _secret_key or "testing-only-insecure-key"
 
 # Performance: cache static files long and enable simple cache-busting
 app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 60 * 60 * 24 * 365  # 1 year
+# Limit upload size to 16 MB
+app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
 try:
     static_css_dir = (Path(__file__).resolve().parent / "static" / "css")
     latest_css_mtime = max((p.stat().st_mtime for p in static_css_dir.glob("*.css")), default=time())
@@ -54,6 +77,47 @@ except Exception:
 # Enable gzip compression if available
 if Compress is not None:
     Compress(app)
+
+# CSRF protection
+if _csrf_available:
+    csrf = CSRFProtect(app)
+
+# HTML sanitisation allowlist (for admin-editable rich-text fields)
+_ALLOWED_TAGS = [
+    "p", "br", "strong", "em", "b", "i", "u", "s",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li", "blockquote", "pre", "code",
+    "a", "img", "figure", "figcaption", "hr", "span", "div",
+]
+_ALLOWED_ATTRS = {
+    "a": ["href", "title", "target", "rel"],
+    "img": ["src", "alt", "width", "height", "loading", "class"],
+    "*": ["class"],
+}
+
+
+def sanitize_html(value):
+    """Sanitize HTML from admin rich-text fields using a tag/attr allowlist."""
+    if not isinstance(value, str):
+        return value
+    if _bleach_available:
+        return _bleach.clean(value, tags=_ALLOWED_TAGS, attributes=_ALLOWED_ATTRS)
+    return value
+
+
+# YouTube URL validation – only allow known YouTube domains
+_YOUTUBE_RE = re.compile(
+    r'^https?://(?:www\.)?(?:youtube\.com/watch\?(?:.*&)?v=|youtu\.be/)([\w-]{11})'
+)
+
+
+def _safe_youtube_embed(url):
+    """Convert a YouTube watch URL to a privacy-enhanced embed URL, or return ''."""
+    m = _YOUTUBE_RE.match(url or "")
+    if not m:
+        return ""
+    return f"https://www.youtube-nocookie.com/embed/{m.group(1)}"
+
 
 ADMIN_USER = os.environ.get("ADMIN_USER", "admin")
 # Plaintext password support (preferred if set). Fallback to legacy hash.
@@ -549,6 +613,38 @@ def asset(path: str):
         return path
     return url_for("static", filename=path)
 
+@app.template_filter("safe_youtube_embed")
+def safe_youtube_embed_filter(url):
+    """Convert YouTube watch URL to privacy-enhanced embed URL."""
+    return _safe_youtube_embed(url)
+
+# --------------------------------------------------
+# Security Headers
+# --------------------------------------------------
+@app.after_request
+def set_security_headers(response):
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+    # CSP: inline scripts/styles kept for Bootstrap + custom JS; frame-src for YouTube
+    csp = (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com "
+        "https://unpkg.com https://analytics.aixtraball.de; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.quilljs.com "
+        "https://fonts.googleapis.com https://unpkg.com; "
+        "font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; "
+        "img-src 'self' data: https:; "
+        "frame-src https://www.youtube-nocookie.com https://www.youtube.com; "
+        "connect-src 'self' https://analytics.aixtraball.de; "
+        "base-uri 'self'; "
+        "form-action 'self';"
+    )
+    response.headers.setdefault("Content-Security-Policy", csp)
+    return response
+
+
 # --------------------------------------------------
 # Routen
 # --------------------------------------------------
@@ -731,6 +827,8 @@ def admin():
 @app.route("/admin/edit/<path:filename>", methods=["GET", "POST"])
 @login_required
 def admin_edit(filename):
+    if filename not in ADMIN_SECTIONS:
+        abort(404)
     filepath = CONFIG_DIR / filename
     if request.method == "POST":
         json_data = request.form.get("content", "")
@@ -855,6 +953,8 @@ def admin_item(filename, index=None):
                 elif ftype == "password":
                     value = request.form.get(key, "")
                     new_item[key] = value
+                elif ftype == "html":
+                    new_item[key] = sanitize_html(request.form.get(key, ""))
                 else:
                     new_item[key] = request.form.get(key, "").strip()
             if filename == "news.yaml":

--- a/app/templates/admin_edit.html
+++ b/app/templates/admin_edit.html
@@ -9,6 +9,7 @@
 <div class="container py-4">
   <h1>{{ filename }}</h1>
   <form method="post" id="editor-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div id="editor" style="height: 500px;"></div>
     <input type="hidden" name="content" id="json-input">
     <button class="btn btn-primary mt-3" type="submit">Speichern</button>

--- a/app/templates/admin_item.html
+++ b/app/templates/admin_item.html
@@ -27,6 +27,7 @@
 
   <form method="post" enctype="multipart/form-data" class="card shadow-sm">
     <div class="card-body">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="__index" value="{% if index is not none %}{{ index }}{% endif %}">
       {% set field_defs = schema if schema else [] %}
       {% if field_defs %}

--- a/app/templates/admin_manage.html
+++ b/app/templates/admin_manage.html
@@ -30,6 +30,7 @@
   {% if filename == 'news.yaml' %}
   <div class="card shadow-sm mb-4">
     <form method="post" action="{{ url_for('admin_news_settings') }}" class="card-body row g-3 align-items-end">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="col-md-6">
         <label class="form-label fw-semibold" for="homepage-limit-input">News auf der Startseite</label>
         <input type="number"
@@ -127,6 +128,7 @@
                     class="d-inline m-0"
                     action="{{ url_for('admin_delete', filename=filename, index=loop.index0) }}"
                     onsubmit="return confirm('Diesen Eintrag wirklich löschen?');">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button class="btn btn-outline-danger" type="submit">
                   <i class="bi bi-trash me-1"></i> Löschen
                 </button>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -96,7 +96,8 @@
              alt="Logo" height="32"
              class="d-inline-block align-text-top">
       </a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+              aria-controls="navbarNav" aria-expanded="false" aria-label="Navigation aufklappen">
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
@@ -166,6 +167,7 @@
             </a>
             <a href="https://www.youtube.com/@aixtraballflippervereinaac2208" target="_blank" class="text-muted" aria-label="YouTube">
               <i class="bi bi-youtube fs-5"></i>
+            </a>
             <a href="https://www.instagram.com/aixtraball/" target="_blank" class="text-muted" aria-label="Instagram">
               <i class="bi bi-instagram"></i>
             </a>

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -33,6 +33,7 @@
           <div class="card-body p-4">
             <h2 class="h4 mb-3">Schreib uns</h2>
             <form method="post" novalidate>
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <div class="form-honeypot">
                 <label>Website</label>
                 <input type="text" name="website" tabindex="-1" autocomplete="off">

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -68,7 +68,10 @@
               </div>
 
               <div class="d-grid d-sm-flex gap-2 mt-4">
-                <button type="submit" class="btn btn-primary">Absenden</button>
+                <button type="submit" class="btn btn-primary" id="contactSubmitBtn">
+                  <span class="spinner-border spinner-border-sm me-2 d-none" id="contactSpinner" aria-hidden="true"></span>
+                  Absenden
+                </button>
               </div>
               <p class="text-muted small mt-2 mb-0">Wir speichern deine Anfrage ausschließlich zur Bearbeitung. Keine Weitergabe an Dritte.</p>
             </form>
@@ -104,6 +107,19 @@
 {% endblock %}
 
 {% block scripts %}
+<script defer>
+  document.addEventListener('DOMContentLoaded', function() {
+    var form = document.querySelector('form[method="post"]');
+    if (form) {
+      form.addEventListener('submit', function() {
+        var spinner = document.getElementById('contactSpinner');
+        var btn = document.getElementById('contactSubmitBtn');
+        if (spinner) spinner.classList.remove('d-none');
+        if (btn) btn.disabled = true;
+      });
+    }
+  });
+</script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" defer></script>
 <script defer>
   document.addEventListener('DOMContentLoaded', function(){

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -16,6 +16,7 @@
                 Gib nun den 6-stelligen Code aus deiner Authenticator-App ein.
               </p>
               <form method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="stage" value="mfa">
                 <div class="mb-3">
                   <label class="form-label">MFA-Code</label>
@@ -36,6 +37,7 @@
               </div>
             {% else %}
               <form method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="hidden" name="stage" value="password">
                 <div class="mb-3">
                   <label class="form-label">Benutzername</label>

--- a/app/templates/news_detail.html
+++ b/app/templates/news_detail.html
@@ -60,7 +60,7 @@
     {% endif %}
     {% if article.youtube_links %}
       <div class="ratio ratio-16x9 my-4">
-        <iframe src="{{ article.youtube_links[0] | replace('watch?v=', 'embed/') }}" allowfullscreen></iframe>
+        <iframe src="{{ article.youtube_links[0] | safe_youtube_embed }}" allowfullscreen></iframe>
       </div>
     {% endif %}
     <a href="{{ url_for('news_list') }}">&larr; Zurück zu allen News</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ PyYAML
 python-dateutil
 gunicorn
 Flask-Compress
+Flask-WTF
+bleach
 PyOTP

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,96 +1,92 @@
 """
-Smoke‑Tests: Überprüft, ob alle Haupt­seiten HTTP 200 liefern.
-Die YAML‑Dateien werden zur Laufzeit minimal erzeugt, damit die
-Flask‑App auch in der CI ohne Volumes funktioniert.
+Smoke‑Tests: Überprüft, ob alle Haupt­seiten HTTP 200 liefern.
+YAML‑Testdaten werden in ein temporäres Verzeichnis geschrieben,
+damit Produktions­dateien in app/config/ nicht überschrieben werden.
 """
 import pathlib, yaml, pytest, re
 from datetime import datetime, timedelta
 
 # ------------------------------------------------------------------
-# 1  Dummy‑YAMLs anlegen
+# 1  Import Flask‑App
 # ------------------------------------------------------------------
-BASE_DIR = pathlib.Path(__file__).resolve().parents[1] / "app"
-CONFIG   = BASE_DIR / "config"
-CONFIG.mkdir(parents=True, exist_ok=True)
+from app.app import app as flask_app   # noqa: E402
 
-def _write(name: str, data):
-    (CONFIG / name).write_text(yaml.safe_dump(data, allow_unicode=True),
-                               encoding="utf-8")
-
-# Öffnungstag in ~30 Tagen
-t0 = datetime.now() + timedelta(days=30)
-t1 = t0 + timedelta(hours=4)
-
-_write("opening_days.yaml", [
-    {"from": t0.strftime("%Y-%m-%d %H:%M"),
-     "to"  : t1.strftime("%Y-%m-%d %H:%M")}
-])
-
-_write("flippers.yaml", [
-    {"name": "Test Machine",
-     "image": "images/test.jpg",
-     "link" : "https://example.com"}
-])
-
-_write("slides.yaml", [
-    {"image": "images/slide.jpg"}
-])
-
-_write("news.yaml", [
-    {"title": "Dummy-News",
-     "date" : datetime.now().strftime("%Y-%m-%d"),
-     "slug" : "dummy-news",
-     "preview_image": "images/slide.jpg"}
-])
-
-_write("members.yaml", [
-    {"name" : "Jane Doe",
-     "role" : "Chairwoman",
-     "image": "images/team.jpg"}
-])
-
-_write("timeline.yaml", [
-    {"date": "2015-03",
-     "title": "Gründung",
-     "description": "Vereinsgründung in Würselen."},
-    {"date": "2016-07",
-     "title": "Erste Ausstellung",
-     "description": "Erste öffentliche Präsentation."}
-])
 
 # ------------------------------------------------------------------
-# 2  Flask importieren & testen
+# 2  Hilfsfunktion: YAMLs in ein beliebiges Verzeichnis schreiben
 # ------------------------------------------------------------------
-from app.app import app as flask_app   # noqa: E402  (Import nach _write)
+def _write(config_dir: pathlib.Path, name: str, data):
+    (config_dir / name).write_text(
+        yaml.safe_dump(data, allow_unicode=True), encoding="utf-8"
+    )
 
+
+def _populate_config(config_dir: pathlib.Path):
+    """Befüllt config_dir mit Minimal‑YAMLs für die Tests."""
+    t0 = datetime.now() + timedelta(days=30)
+    t1 = t0 + timedelta(hours=4)
+
+    _write(config_dir, "opening_days.yaml", [
+        {"from": t0.strftime("%Y-%m-%d %H:%M"),
+         "to":   t1.strftime("%Y-%m-%d %H:%M")}
+    ])
+    _write(config_dir, "flippers.yaml", [
+        {"name": "Test Machine",
+         "image": "images/test.jpg",
+         "link":  "https://example.com"}
+    ])
+    _write(config_dir, "slides.yaml", [
+        {"image": "images/slide.jpg"}
+    ])
+    _write(config_dir, "news.yaml", [
+        {"title": "Dummy-News",
+         "date":  datetime.now().strftime("%Y-%m-%d"),
+         "slug":  "dummy-news",
+         "preview_image": "images/slide.jpg"}
+    ])
+    _write(config_dir, "members.yaml", [
+        {"name": "Jane Doe", "role": "Chairwoman", "image": "images/team.jpg"}
+    ])
+    _write(config_dir, "timeline.yaml", [
+        {"date": "2015-03", "title": "Gründung",          "description": "Vereinsgründung in Würselen."},
+        {"date": "2016-07", "title": "Erste Ausstellung",  "description": "Erste öffentliche Präsentation."},
+    ])
+    _write(config_dir, "news_settings.yaml", {"homepage_limit": 2})
+
+
+# ------------------------------------------------------------------
+# 3  Client‑Fixture – isoliertes tmp‑Verzeichnis, kein Overwrite
+# ------------------------------------------------------------------
 @pytest.fixture
-def client():
+def client(tmp_path):
+    _populate_config(tmp_path)
     flask_app.config["TESTING"] = True
     flask_app.config["WTF_CSRF_ENABLED"] = False
+    flask_app.config["CONFIG_DIR"] = tmp_path
+    # YAML‑Cache leeren, damit Tests nicht gegenseitig stören
+    from app.app import YAML_CACHE
+    YAML_CACHE.clear()
     with flask_app.test_client() as c:
         yield c
 
+
 # ------------------------------------------------------------------
-# 3  Smoke‑Tests: alle wichtigen Routen
+# 4  Smoke‑Tests: alle wichtigen Routen
 # ------------------------------------------------------------------
 @pytest.mark.parametrize(
     "route",
-    ["/", "/verein", "/team", "/flipper", "/news",
-     "/preise"]                     # ← neu
+    ["/", "/verein", "/team", "/flipper", "/news", "/preise"]
 )
 def test_routes_return_200(client, route):
     resp = client.get(route)
     assert resp.status_code == 200
 
+
 # ------------------------------------------------------------------
-# 4  Timeline‑Inhalt erscheint auf /verein
+# 5  Timeline‑Inhalt erscheint auf /verein
 # ------------------------------------------------------------------
-def test_timeline_visible_on_verein(client):
-    """
-    Erstes Timeline‑Element aus timeline.yaml muss im
-    gerendeten HTML der Vereins‑Seite vorkommen.
-    """
-    timeline = yaml.safe_load((CONFIG / "timeline.yaml").read_text())
+def test_timeline_visible_on_verein(client, tmp_path):
+    timeline = yaml.safe_load((tmp_path / "timeline.yaml").read_text())
     assert timeline, "timeline.yaml ist leer"
 
     first_title = timeline[0]["title"]
@@ -98,23 +94,26 @@ def test_timeline_visible_on_verein(client):
 
     assert first_title in html, "Timeline‑Titel nicht gefunden"
 
+
 # ------------------------------------------------------------------
-# 5  Aktueller Öffnungstag bleibt sichtbar
+# 6  Aktueller Öffnungstag bleibt sichtbar
 # ------------------------------------------------------------------
-def test_current_opening_visible(client):
+def test_current_opening_visible(client, tmp_path):
     """Wenn gerade ein Öffnungstag läuft, soll er auf der Startseite erscheinen."""
+    from app.app import YAML_CACHE
     now = datetime.now()
     t_from = now - timedelta(hours=1)
-    t_to = now + timedelta(hours=1)
+    t_to   = now + timedelta(hours=1)
     next_from = now + timedelta(days=1)
-    next_to = next_from + timedelta(hours=4)
+    next_to   = next_from + timedelta(hours=4)
 
-    _write("opening_days.yaml", [
+    _write(tmp_path, "opening_days.yaml", [
         {"from": t_from.strftime("%Y-%m-%d %H:%M"),
-         "to": t_to.strftime("%Y-%m-%d %H:%M")},
+         "to":   t_to.strftime("%Y-%m-%d %H:%M")},
         {"from": next_from.strftime("%Y-%m-%d %H:%M"),
-         "to": next_to.strftime("%Y-%m-%d %H:%M")},
+         "to":   next_to.strftime("%Y-%m-%d %H:%M")},
     ])
+    YAML_CACHE.clear()
 
     html = client.get("/").data.decode()
 
@@ -123,7 +122,7 @@ def test_current_opening_visible(client):
 
 
 # ------------------------------------------------------------------
-# 6  Login schützt vor Brute-Force durch Limitierung
+# 7  Login schützt vor Brute-Force
 # ------------------------------------------------------------------
 def _captcha_answer(html: str) -> str:
     m = re.search(r"(\d+) \+ (\d+)", html)
@@ -150,8 +149,11 @@ def test_login_rate_limit(client):
     assert b"Zu viele Fehlversuche" in resp.data
 
 
-def test_admin_add_entry_via_form(client):
-    from app.app import LOGIN_ATTEMPTS
+# ------------------------------------------------------------------
+# 8  Admin: neuen Eintrag anlegen
+# ------------------------------------------------------------------
+def test_admin_add_entry_via_form(client, tmp_path):
+    from app.app import LOGIN_ATTEMPTS, YAML_CACHE
     LOGIN_ATTEMPTS.clear()
     html = client.get("/login").data.decode()
     answer = _captcha_answer(html)
@@ -165,5 +167,6 @@ def test_admin_add_entry_via_form(client):
         data={"name": "Neu", "image": "images/x.jpg", "link": "https://ex"},
         follow_redirects=True,
     )
-    data = yaml.safe_load((CONFIG / "flippers.yaml").read_text())
+    YAML_CACHE.clear()
+    data = yaml.safe_load((tmp_path / "flippers.yaml").read_text())
     assert any(f.get("name") == "Neu" for f in data)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 # ------------------------------------------------------------------
 # 1  Import Flask‑App
 # ------------------------------------------------------------------
-from app.app import app as flask_app   # noqa: E402
+from app.app import app as flask_app, YAML_CACHE, LOGIN_ATTEMPTS  # noqa: E402
 
 
 # ------------------------------------------------------------------
@@ -63,8 +63,6 @@ def client(tmp_path):
     flask_app.config["TESTING"] = True
     flask_app.config["WTF_CSRF_ENABLED"] = False
     flask_app.config["CONFIG_DIR"] = tmp_path
-    # YAML‑Cache leeren, damit Tests nicht gegenseitig stören
-    from app.app import YAML_CACHE
     YAML_CACHE.clear()
     with flask_app.test_client() as c:
         yield c
@@ -100,7 +98,6 @@ def test_timeline_visible_on_verein(client, tmp_path):
 # ------------------------------------------------------------------
 def test_current_opening_visible(client, tmp_path):
     """Wenn gerade ein Öffnungstag läuft, soll er auf der Startseite erscheinen."""
-    from app.app import YAML_CACHE
     now = datetime.now()
     t_from = now - timedelta(hours=1)
     t_to   = now + timedelta(hours=1)
@@ -153,7 +150,6 @@ def test_login_rate_limit(client):
 # 8  Admin: neuen Eintrag anlegen
 # ------------------------------------------------------------------
 def test_admin_add_entry_via_form(client, tmp_path):
-    from app.app import LOGIN_ATTEMPTS, YAML_CACHE
     LOGIN_ATTEMPTS.clear()
     html = client.get("/login").data.decode()
     answer = _captcha_answer(html)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -66,6 +66,7 @@ from app.app import app as flask_app   # noqa: E402  (Import nach _write)
 @pytest.fixture
 def client():
     flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
     with flask_app.test_client() as c:
         yield c
 


### PR DESCRIPTION
- Require SECRET_KEY env var at startup (no insecure default)
- Add HTTP security headers via @after_request (CSP, X-Frame-Options,
  X-Content-Type-Options, Referrer-Policy, Permissions-Policy)
- Add CSRF protection on all POST forms via Flask-WTF
- Sanitize admin HTML input with bleach before saving to YAML
- Validate YouTube URLs with regex, use youtube-nocookie.com embed
- Fix path traversal in admin_edit: enforce ADMIN_SECTIONS whitelist
- Set MAX_CONTENT_LENGTH = 16 MB for file uploads
- Disable WTF_CSRF_ENABLED in test fixture

https://claude.ai/code/session_01J4zbCqZQGmxNAB2WVo1UMZ