### PR TITLE
Kontaktseite: Umbennung und Anmietungs-Anfrage

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -239,18 +239,22 @@ def _resolve_smtp_recipients():
     return [addr.strip() for addr in normalized.split(",") if addr.strip()]
 
 
-def send_contact_email(payload: dict):
+def send_contact_email(payload: dict, recipient_override: str | None = None):
     """Send contact form payload via SMTP."""
     if app.config.get("TESTING"):
         return
     if not (SMTP_HOST and SMTP_USERNAME and SMTP_PASSWORD):
         raise SMTPConfigurationError("SMTP credentials are incomplete.")
-    recipients = _resolve_smtp_recipients()
+    if recipient_override:
+        recipients = [recipient_override]
+    else:
+        recipients = _resolve_smtp_recipients()
     if not recipients:
         raise SMTPConfigurationError("No SMTP recipients configured.")
     sender = SMTP_SENDER or SMTP_USERNAME
     msg = EmailMessage()
-    msg["Subject"] = f"Neue Kontaktanfrage von {payload.get('name') or 'Unbekannt'}"
+    subject_prefix = "Anmietungsanfrage" if recipient_override else "Kontaktanfrage"
+    msg["Subject"] = f"Neue {subject_prefix} von {payload.get('name') or 'Unbekannt'}"
     msg["From"] = sender
     msg["To"] = ", ".join(recipients)
     reply_to = payload.get("email")
@@ -1568,11 +1572,12 @@ def kontakt():
             return redirect(url_for("kontakt"))
         _register_attempt()
 
-        name    = request.form.get("name", "").strip()
-        email   = request.form.get("email", "").strip()
-        message = request.form.get("message", "").strip()
-        consent = request.form.get("consent") == "on"
-        captcha = request.form.get("captcha", "").strip()
+        name         = request.form.get("name", "").strip()
+        email        = request.form.get("email", "").strip()
+        message      = request.form.get("message", "").strip()
+        consent      = request.form.get("consent") == "on"
+        captcha      = request.form.get("captcha", "").strip()
+        inquiry_type = request.form.get("inquiry_type", "allgemein").strip()
 
         if not (name and email and message and consent and captcha):
             flash("Bitte alle Pflichtfelder ausfüllen und zustimmen.", "warning")
@@ -1585,16 +1590,19 @@ def kontakt():
             )
             return redirect(url_for("kontakt"))
 
+        rental_recipient = "vermietung@aixtraball.de" if inquiry_type == "anmietung" else None
+
         payload = {
             "name": name,
             "email": email,
             "message": message,
+            "inquiry_type": inquiry_type,
             "timestamp": datetime.now(tz=tz.gettz("Europe/Berlin")).isoformat(),
             "ip": request.remote_addr,
             "ua": request.headers.get("User-Agent", "")
         }
         try:
-            send_contact_email(payload)
+            send_contact_email(payload, recipient_override=rental_recipient)
         except SMTPConfigurationError as exc:
             app.logger.error("Kontaktformular: SMTP-Konfiguration fehlt: %s", exc)
             flash("Der Mail-Versand ist derzeit nicht konfiguriert. Bitte versuchen Sie es später erneut.", "danger")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -137,7 +137,7 @@
           <li class="nav-item"><a class="nav-link{% if request.endpoint in ('news_list','news_detail') %} active{% endif %}" href="{{ url_for('news_list') }}">News</a></li>
           <li class="nav-item"><a class="nav-link{% if request.endpoint == 'team' %} active{% endif %}" href="{{ url_for('team') }}">Das Team</a></li>
           <li class="nav-item"><a class="nav-link{% if request.endpoint == 'preise' %} active{% endif %}" href="{{ url_for('preise') }}">Preise &amp; Besuch</a></li>
-          <li class="nav-item"><a class="nav-link{% if request.endpoint == 'kontakt' %} active{% endif %}" href="{{ url_for('kontakt') }}">Kontakt</a></li>
+          <li class="nav-item"><a class="nav-link{% if request.endpoint == 'kontakt' %} active{% endif %}" href="{{ url_for('kontakt') }}">Kontakt und Anmietung</a></li>
           <li class="nav-item"><a class="nav-link{% if request.endpoint == 'impressum' %} active{% endif %}" href="{{ url_for('impressum') }}">Impressum</a></li>
           {% if session.get('logged_in') %}
           <li class="nav-item"><a class="nav-link" href="{{ url_for('admin') }}">Admin</a></li>

--- a/app/templates/contact.html
+++ b/app/templates/contact.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block title %}Kontakt – Aixtraball e.V.{% endblock %}
+{% block title %}Kontakt und Anmietung – Aixtraball e.V.{% endblock %}
 {% block meta_description %}Kontakt zum Aixtraball e.V.: Adresse Merzbrück 210, 52146 Würselen, E‑Mail und Öffnungstage. Jetzt anfragen.{% endblock %}
 {% block head_extra %}
 <style>
@@ -12,7 +12,7 @@
 <header class="page-hero" style="background-image:url('{{ url_for("static", filename="images/else/background_contact.png") }}')">
   <div class="page-hero-content">
     <div class="eyebrow">Schreib uns</div>
-    <h1>Kontakt</h1>
+    <h1>Kontakt und Anmietung</h1>
     <p class="lead">Frag uns alles rund um Verein, Besuch &amp; Events</p>
   </div>
 </header>
@@ -29,6 +29,20 @@
               <div class="form-honeypot">
                 <label>Website</label>
                 <input type="text" name="website" tabindex="-1" autocomplete="off">
+              </div>
+
+              <div class="mb-3">
+                <label class="form-label">Art der Anfrage</label>
+                <div class="d-flex gap-4">
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="inquiry_type" id="inquiry_general" value="allgemein" checked>
+                    <label class="form-check-label" for="inquiry_general">Allgemeine Anfrage</label>
+                  </div>
+                  <div class="form-check">
+                    <input class="form-check-input" type="radio" name="inquiry_type" id="inquiry_rental" value="anmietung">
+                    <label class="form-check-label" for="inquiry_rental">Anmietung</label>
+                  </div>
+                </div>
               </div>
 
               <div class="row g-3">


### PR DESCRIPTION
Menüpunkt und Seite von "Kontakt" zu "Kontakt und Anmietung" umbenannt. Formular um Radio-Buttons "Allgemeine Anfrage" / "Anmietung" erweitert; bei Anmietung wird die E-Mail an vermietung@aixtraball.de weitergeleitet.